### PR TITLE
Fixing the shallow copy problem in JPetEvent

### DIFF
--- a/include/Core/JPetAnalysisTools/JPetAnalysisTools.h
+++ b/include/Core/JPetAnalysisTools/JPetAnalysisTools.h
@@ -25,5 +25,6 @@
 namespace jpet_analysis_tools
 {
 void orderHitsByTime(std::vector<std::unique_ptr<JPetBaseHit>>& hits);
+std::vector<const JPetBaseHit*> orderHitsByTime(std::vector<const JPetBaseHit*>& hits);
 };
 #endif /* !JPETANALYSISTOOLS_H */

--- a/include/Core/JPetAnalysisTools/JPetAnalysisTools.h
+++ b/include/Core/JPetAnalysisTools/JPetAnalysisTools.h
@@ -22,9 +22,8 @@
 /**
  * @brief Class with the set of methods that can be useful for different analyses.
  */
-class JPetAnalysisTools
+namespace jpet_analysis_tools
 {
-public:
-  static std::vector<const JPetBaseHit*> getHitsOrderedByTime(const std::vector<const JPetBaseHit*>& hits);
+void orderHitsByTime(std::vector<std::unique_ptr<JPetBaseHit>>& hits);
 };
 #endif /* !JPETANALYSISTOOLS_H */

--- a/include/DataObjects/Hits/JPetBaseHit/JPetBaseHit.h
+++ b/include/DataObjects/Hits/JPetBaseHit/JPetBaseHit.h
@@ -35,6 +35,7 @@ public:
   JPetBaseHit(double time, double energy, TVector3& position);
   JPetBaseHit(double time, double energy, TVector3& position, JPetScin& scin);
   virtual ~JPetBaseHit();
+  virtual JPetBaseHit* clone() const;
   double getTime() const;
   double getEnergy() const;
   double getPosX() const;

--- a/include/DataObjects/Hits/JPetMCRecoHit/JPetMCRecoHit.h
+++ b/include/DataObjects/Hits/JPetMCRecoHit/JPetMCRecoHit.h
@@ -30,6 +30,7 @@ public:
   JPetMCRecoHit();
   explicit JPetMCRecoHit(int mcIndex);
   virtual ~JPetMCRecoHit();
+  virtual JPetMCRecoHit* clone() const override;
   unsigned int getMCindex() const;
   void setMCindex(unsigned int i);
   void Clear(Option_t*) override;

--- a/include/DataObjects/Hits/JPetPhysRecoHit/JPetPhysRecoHit.h
+++ b/include/DataObjects/Hits/JPetPhysRecoHit/JPetPhysRecoHit.h
@@ -40,6 +40,7 @@ public:
   };
   JPetPhysRecoHit();
   virtual ~JPetPhysRecoHit();
+  virtual JPetPhysRecoHit* clone() const override;
 
   void setTimeDiff(double timeDiff);
   void setToT(double tot);

--- a/include/DataObjects/Hits/JPetRecoHit/JPetRecoHit.h
+++ b/include/DataObjects/Hits/JPetRecoHit/JPetRecoHit.h
@@ -41,6 +41,7 @@ public:
   JPetRecoHit();
   explicit JPetRecoHit(JPetRecoHit::RecoFlag flag);
   virtual ~JPetRecoHit();
+  virtual JPetRecoHit* clone() const override;
   JPetRecoHit::RecoFlag getRecoFlag() const;
   void setRecoFlag(JPetRecoHit::RecoFlag flag);
   void Clear(Option_t*) override;

--- a/include/DataObjects/JPetEvent/JPetEvent.h
+++ b/include/DataObjects/JPetEvent/JPetEvent.h
@@ -55,8 +55,11 @@ public:
   JPetEvent(const std::vector<const JPetBaseHit*>& hits, JPetEventType eventType = JPetEventType::kUnknown, bool orderedByTime = true);
   ///@TODO add move and = operators and virtual disestructor (rule of five!)
   JPetEvent(const JPetEvent& other);
+  JPetEvent& operator=(const JPetEvent& other);
   JPetEvent::RecoFlag getRecoFlag() const;
-  const std::vector<const JPetBaseHit*>& getHits() const;
+  const std::vector<const JPetBaseHit*> getHits() const;
+  std::vector<std::unique_ptr<JPetBaseHit>>& getHits2();
+  std::vector<JPetBaseHit*> getHitsCopy() const;
   void setRecoFlag(JPetEvent::RecoFlag flag);
   void setHits(const std::vector<const JPetBaseHit*>& hits, bool orderedByTime = true);
   void addHit(const JPetBaseHit* hit);
@@ -68,7 +71,7 @@ public:
   void Clear(Option_t*) override;
 
 protected:
-  std::vector<const JPetBaseHit*> fHits;
+  std::vector<std::unique_ptr<JPetBaseHit>> fHits;
   JPetEventType fType = JPetEventType::kUnknown;
 
 private:

--- a/include/DataObjects/JPetEvent/JPetEvent.h
+++ b/include/DataObjects/JPetEvent/JPetEvent.h
@@ -58,8 +58,6 @@ public:
   JPetEvent& operator=(const JPetEvent& other);
   JPetEvent::RecoFlag getRecoFlag() const;
   const std::vector<const JPetBaseHit*> getHits() const;
-  std::vector<std::unique_ptr<JPetBaseHit>>& getHits2();
-  std::vector<JPetBaseHit*> getHitsCopy() const;
   void setRecoFlag(JPetEvent::RecoFlag flag);
   void setHits(const std::vector<const JPetBaseHit*>& hits, bool orderedByTime = true);
   void addHit(const JPetBaseHit* hit);

--- a/include/DataObjects/JPetEvent/JPetEvent.h
+++ b/include/DataObjects/JPetEvent/JPetEvent.h
@@ -53,6 +53,8 @@ public:
 
   JPetEvent();
   JPetEvent(const std::vector<const JPetBaseHit*>& hits, JPetEventType eventType = JPetEventType::kUnknown, bool orderedByTime = true);
+  ///@TODO add move and = operators and virtual disestructor (rule of five!)
+  JPetEvent(const JPetEvent& other);
   JPetEvent::RecoFlag getRecoFlag() const;
   const std::vector<const JPetBaseHit*>& getHits() const;
   void setRecoFlag(JPetEvent::RecoFlag flag);

--- a/include/MC/JPetRawMCHit/JPetRawMCHit.h
+++ b/include/MC/JPetRawMCHit/JPetRawMCHit.h
@@ -27,6 +27,7 @@ class JPetRawMCHit : public JPetBaseHit
 {
 public:
   JPetRawMCHit();
+  virtual JPetRawMCHit* clone() const override;
   int getMCDecayTreeIndex() const;
   int getMCVtxIndex() const;
   const TVector3& getPolarization() const;

--- a/src/Core/JPetAnalysisTools/JPetAnalysisTools.cpp
+++ b/src/Core/JPetAnalysisTools/JPetAnalysisTools.cpp
@@ -27,4 +27,11 @@ void orderHitsByTime(std::vector<std::unique_ptr<JPetBaseHit>>& hits)
             [](const std::unique_ptr<JPetBaseHit>& h1, const std::unique_ptr<JPetBaseHit>& h2) -> bool { return h1->getTime() < h2->getTime(); });
 }
 
+std::vector<const JPetBaseHit*> orderHitsByTime(std::vector<const JPetBaseHit*>& oldHits)
+{
+  auto hits(oldHits);
+  std::sort(hits.begin(), hits.end(), [](const JPetBaseHit* h1, const JPetBaseHit* h2) -> bool { return h1->getTime() < h2->getTime(); });
+  return hits;
+}
+
 } // namespace jpet_analysis_tools

--- a/src/Core/JPetAnalysisTools/JPetAnalysisTools.cpp
+++ b/src/Core/JPetAnalysisTools/JPetAnalysisTools.cpp
@@ -18,9 +18,13 @@
 /**
  * Sorting the input vector of JPetHits by ascending time
  */
-std::vector<const JPetBaseHit*> JPetAnalysisTools::getHitsOrderedByTime(const std::vector<const JPetBaseHit*>& oldHits)
+namespace jpet_analysis_tools
 {
-  auto hits(oldHits);
-  std::sort(hits.begin(), hits.end(), [](const JPetBaseHit* h1, const JPetBaseHit* h2) { return h1->getTime() < h2->getTime(); });
-  return hits;
+
+void orderHitsByTime(std::vector<std::unique_ptr<JPetBaseHit>>& hits)
+{
+  std::sort(hits.begin(), hits.end(),
+            [](const std::unique_ptr<JPetBaseHit>& h1, const std::unique_ptr<JPetBaseHit>& h2) -> bool { return h1->getTime() < h2->getTime(); });
 }
+
+} // namespace jpet_analysis_tools

--- a/src/DataObjects/Hits/JPetBaseHit/JPetBaseHit.cpp
+++ b/src/DataObjects/Hits/JPetBaseHit/JPetBaseHit.cpp
@@ -27,6 +27,8 @@ JPetBaseHit::JPetBaseHit(double time, double energy, TVector3& position, JPetSci
 {
 }
 
+JPetBaseHit* JPetBaseHit::clone() const { return new JPetBaseHit(*this); }
+
 JPetBaseHit::~JPetBaseHit() {}
 
 /**

--- a/src/DataObjects/Hits/JPetMCRecoHit/JPetMCRecoHit.cpp
+++ b/src/DataObjects/Hits/JPetMCRecoHit/JPetMCRecoHit.cpp
@@ -23,6 +23,8 @@ JPetMCRecoHit::JPetMCRecoHit(int mcIndex) : JPetRecoHit(JPetRecoHit::MC), fMCind
 
 JPetMCRecoHit::~JPetMCRecoHit() {}
 
+JPetMCRecoHit* JPetMCRecoHit::clone() const { return new JPetMCRecoHit(*this); }
+
 unsigned int JPetMCRecoHit::getMCindex() const { return fMCindex; }
 
 void JPetMCRecoHit::setMCindex(unsigned int i) { fMCindex = i; }

--- a/src/DataObjects/Hits/JPetPhysRecoHit/JPetPhysRecoHit.cpp
+++ b/src/DataObjects/Hits/JPetPhysRecoHit/JPetPhysRecoHit.cpp
@@ -22,6 +22,8 @@ JPetPhysRecoHit::JPetPhysRecoHit() : JPetRecoHit() {}
 
 JPetPhysRecoHit::~JPetPhysRecoHit() {}
 
+JPetPhysRecoHit* JPetPhysRecoHit::clone() const { return new JPetPhysRecoHit(*this); }
+
 void JPetPhysRecoHit::setTimeDiff(double timeDiff) { fTimeDiff = timeDiff; }
 
 void JPetPhysRecoHit::setToT(double tot) { fToT = tot; }

--- a/src/DataObjects/Hits/JPetRecoHit/JPetRecoHit.cpp
+++ b/src/DataObjects/Hits/JPetRecoHit/JPetRecoHit.cpp
@@ -23,6 +23,8 @@ JPetRecoHit::JPetRecoHit(JPetRecoHit::RecoFlag flag) : JPetBaseHit(), fFlag(flag
 
 JPetRecoHit::~JPetRecoHit() {}
 
+JPetRecoHit* JPetRecoHit::clone() const { return new JPetRecoHit(*this); }
+
 JPetRecoHit::RecoFlag JPetRecoHit::getRecoFlag() const { return fFlag; }
 
 void JPetRecoHit::setRecoFlag(JPetRecoHit::RecoFlag flag) { fFlag = flag; }

--- a/src/DataObjects/JPetEvent/JPetEvent.cpp
+++ b/src/DataObjects/JPetEvent/JPetEvent.cpp
@@ -85,22 +85,6 @@ const std::vector<const JPetBaseHit*> JPetEvent::getHits() const
 }
 
 /**
- * Get vector of hits being the copies of the hits from that event.
- */
-std::vector<JPetBaseHit*> JPetEvent::getHitsCopy() const
-{
-  std::vector<JPetBaseHit*> vect;
-  std::transform(fHits.begin(), fHits.end(), std::back_inserter(vect), [](auto& item) { return item.get()->clone(); });
-  return vect;
-}
-
-/**
- * Get access to the vector of unique pointers to hits from this event.
- * !Watch out cause it may destroy the hits stored in the event.
- */
-std::vector<std::unique_ptr<JPetBaseHit>>& JPetEvent::getHits2() { return fHits; }
-
-/**
  * Get all the event types.
  */
 JPetEventType JPetEvent::getEventType() const { return fType; }

--- a/src/DataObjects/JPetEvent/JPetEvent.cpp
+++ b/src/DataObjects/JPetEvent/JPetEvent.cpp
@@ -37,22 +37,25 @@ void JPetEvent::setHits(const std::vector<const JPetBaseHit*>& hits, bool ordere
 {
   if (orderedByTime)
   {
+    ///@TODO add unique_ptrs and move in JPetAnalysisTools or normal vectors
     fHits = JPetAnalysisTools::getHitsOrderedByTime(hits);
   }
   else
   {
-    fHits = hits;
+    std::transform(hits.begin(), hits.end(), std::back_inserter(fHits), [](auto& item) { return item->clone(); });
   }
 }
 
 /**
  * Adding hit to the event, this method does not sort nor order added hits by time.
+ * The hit object is actually copied.
  */
-void JPetEvent::addHit(const JPetBaseHit* hit) { fHits.push_back(hit); }
+void JPetEvent::addHit(const JPetBaseHit* hit) { fHits.push_back(hit->clone()); }
 
 /**
  * Get vector of hits from this event.
  */
+/// WK: is it event save?
 const std::vector<const JPetBaseHit*>& JPetEvent::getHits() const { return fHits; }
 
 /**

--- a/src/MC/JPetRawMCHit/JPetRawMCHit.cpp
+++ b/src/MC/JPetRawMCHit/JPetRawMCHit.cpp
@@ -20,6 +20,8 @@ ClassImp(JPetRawMCHit);
 
 JPetRawMCHit::JPetRawMCHit() : JPetBaseHit() {}
 
+JPetRawMCHit* JPetRawMCHit::clone() const { return new JPetRawMCHit(*this); }
+
 int JPetRawMCHit::getMCDecayTreeIndex() const { return fMCDecayTreeIndex; }
 
 int JPetRawMCHit::getMCVtxIndex() const { return fMCVtxIndex; }

--- a/tests/Core/JPetAnalysisTools/JPetAnalysisToolsTest.cpp
+++ b/tests/Core/JPetAnalysisTools/JPetAnalysisToolsTest.cpp
@@ -22,7 +22,6 @@
 using namespace jpet_analysis_tools;
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
-
 BOOST_AUTO_TEST_CASE(constructor_orderHitsByTime)
 {
   TVector3 position(1.0, 1.0, 1.0);
@@ -36,8 +35,8 @@ BOOST_AUTO_TEST_CASE(constructor_orderHitsByTime)
   event.addHit(&hit2);
   event.addHit(&hit3);
   event.addHit(&hit4);
-  auto& hits = event.getHits2();
-  orderHitsByTime(hits);
+  auto hits = event.getHits();
+  hits = orderHitsByTime(hits);
   double epsilon = 0.0001;
   BOOST_REQUIRE_CLOSE(hits[0]->getTime(), 1.1, epsilon);
   BOOST_REQUIRE_CLOSE(hits[1]->getTime(), 2.2, epsilon);
@@ -45,4 +44,25 @@ BOOST_AUTO_TEST_CASE(constructor_orderHitsByTime)
   BOOST_REQUIRE_CLOSE(hits[3]->getTime(), 4.4, epsilon);
 }
 
+BOOST_AUTO_TEST_CASE(constructor_orderHitsByTimeUnique)
+{
+  TVector3 position(1.0, 1.0, 1.0);
+  JPetBaseHit hit1(2.2, 511.0, position);
+  JPetBaseHit hit2(1.1, 511.0, position);
+  JPetBaseHit hit3(4.4, 511.0, position);
+  JPetBaseHit hit4(3.3, 511.0, position);
+
+  std::vector<std::unique_ptr<JPetBaseHit>> hits;
+  hits.emplace_back(new JPetBaseHit(2.2, 511.0, position));
+  hits.emplace_back(new JPetBaseHit(1.1, 511.0, position));
+  hits.emplace_back(new JPetBaseHit(4.4, 511.0, position));
+  hits.emplace_back(new JPetBaseHit(3.3, 511.0, position));
+
+  orderHitsByTime(hits);
+  double epsilon = 0.0001;
+  BOOST_REQUIRE_CLOSE(hits[0]->getTime(), 1.1, epsilon);
+  BOOST_REQUIRE_CLOSE(hits[1]->getTime(), 2.2, epsilon);
+  BOOST_REQUIRE_CLOSE(hits[2]->getTime(), 3.3, epsilon);
+  BOOST_REQUIRE_CLOSE(hits[3]->getTime(), 4.4, epsilon);
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/Core/JPetAnalysisTools/JPetAnalysisToolsTest.cpp
+++ b/tests/Core/JPetAnalysisTools/JPetAnalysisToolsTest.cpp
@@ -19,10 +19,11 @@
 #include "JPetAnalysisTools/JPetAnalysisTools.h"
 #include "JPetEvent/JPetEvent.h"
 #include <boost/test/unit_test.hpp>
+using namespace jpet_analysis_tools;
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 
-BOOST_AUTO_TEST_CASE(constructor_getHitsOrderedByTime)
+BOOST_AUTO_TEST_CASE(constructor_orderHitsByTime)
 {
   TVector3 position(1.0, 1.0, 1.0);
   JPetBaseHit hit1(2.2, 511.0, position);
@@ -35,12 +36,13 @@ BOOST_AUTO_TEST_CASE(constructor_getHitsOrderedByTime)
   event.addHit(&hit2);
   event.addHit(&hit3);
   event.addHit(&hit4);
-  auto results = JPetAnalysisTools::getHitsOrderedByTime(event.getHits());
+  auto& hits = event.getHits2();
+  orderHitsByTime(hits);
   double epsilon = 0.0001;
-  BOOST_REQUIRE_CLOSE(results[0]->getTime(), 1.1, epsilon);
-  BOOST_REQUIRE_CLOSE(results[1]->getTime(), 2.2, epsilon);
-  BOOST_REQUIRE_CLOSE(results[2]->getTime(), 3.3, epsilon);
-  BOOST_REQUIRE_CLOSE(results[3]->getTime(), 4.4, epsilon);
+  BOOST_REQUIRE_CLOSE(hits[0]->getTime(), 1.1, epsilon);
+  BOOST_REQUIRE_CLOSE(hits[1]->getTime(), 2.2, epsilon);
+  BOOST_REQUIRE_CLOSE(hits[2]->getTime(), 3.3, epsilon);
+  BOOST_REQUIRE_CLOSE(hits[3]->getTime(), 4.4, epsilon);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/DataObjects/JPetEvent/JPetEventTest.cpp
+++ b/tests/DataObjects/JPetEvent/JPetEventTest.cpp
@@ -50,18 +50,15 @@ BOOST_AUTO_TEST_CASE(recoFlagSetterTest)
 
 BOOST_AUTO_TEST_CASE(constructor)
 {
-  std::cout << "constructor" << std::endl;
   JPetBaseHit firstHit;
   JPetBaseHit secondHit;
   JPetEvent event({&firstHit, &secondHit}, JPetEventType::kUnknown);
   BOOST_REQUIRE(!event.getHits().empty());
   BOOST_REQUIRE_EQUAL(event.getHits().size(), 2);
-  std::cout << "after constructor" << std::endl;
 }
 
 BOOST_AUTO_TEST_CASE(constructor_orderedHits)
 {
-  std::cout << "constructor orderedHits" << std::endl;
   TVector3 position(1.0, 1.0, 1.0);
   const JPetBaseHit hit1(2.2, 511.0, position);
   const JPetBaseHit hit2(1.1, 511.0, position);
@@ -75,7 +72,6 @@ BOOST_AUTO_TEST_CASE(constructor_orderedHits)
   BOOST_REQUIRE_CLOSE(results[1]->getTime(), 2.2, epsilon);
   BOOST_REQUIRE_CLOSE(results[2]->getTime(), 3.3, epsilon);
   BOOST_REQUIRE_CLOSE(results[3]->getTime(), 4.4, epsilon);
-  std::cout << "after constructor orderedHits" << std::endl;
 }
 
 BOOST_AUTO_TEST_CASE(constructor_unorderedHits)

--- a/tests/DataObjects/JPetEvent/JPetEventTest.cpp
+++ b/tests/DataObjects/JPetEvent/JPetEventTest.cpp
@@ -50,15 +50,18 @@ BOOST_AUTO_TEST_CASE(recoFlagSetterTest)
 
 BOOST_AUTO_TEST_CASE(constructor)
 {
+  std::cout << "constructor" << std::endl;
   JPetBaseHit firstHit;
   JPetBaseHit secondHit;
   JPetEvent event({&firstHit, &secondHit}, JPetEventType::kUnknown);
   BOOST_REQUIRE(!event.getHits().empty());
   BOOST_REQUIRE_EQUAL(event.getHits().size(), 2);
+  std::cout << "after constructor" << std::endl;
 }
 
 BOOST_AUTO_TEST_CASE(constructor_orderedHits)
 {
+  std::cout << "constructor orderedHits" << std::endl;
   TVector3 position(1.0, 1.0, 1.0);
   const JPetBaseHit hit1(2.2, 511.0, position);
   const JPetBaseHit hit2(1.1, 511.0, position);
@@ -72,6 +75,7 @@ BOOST_AUTO_TEST_CASE(constructor_orderedHits)
   BOOST_REQUIRE_CLOSE(results[1]->getTime(), 2.2, epsilon);
   BOOST_REQUIRE_CLOSE(results[2]->getTime(), 3.3, epsilon);
   BOOST_REQUIRE_CLOSE(results[3]->getTime(), 4.4, epsilon);
+  std::cout << "after constructor orderedHits" << std::endl;
 }
 
 BOOST_AUTO_TEST_CASE(constructor_unorderedHits)


### PR DESCRIPTION
-Add clone() methods to JPetXXXHit hierarchy according to clone idiom (see e.g. https://stackoverflow.com/questions/12255546/c-deep-copying-a-base-class-pointer) 
-add copy constructor, assignment operator to JPetEvent
-change member container for hits from raw to unique pointers.
-refactor other methods to rather copy the hits instead of taking the pointers directly.
-change the definition of JPetAnalysisTools function that orders the hits in time. 

The code is not fully tested yet, but I wanted to ask for your opinion @alekgajos @kkacprzak 

